### PR TITLE
fix: fail pipeline on script errors

### DIFF
--- a/.github/scripts/exec-build.sh
+++ b/.github/scripts/exec-build.sh
@@ -1,3 +1,5 @@
+set -euo pipefail
+
 dotnet build
 
 dotnet format

--- a/.github/scripts/exec-deploy.sh
+++ b/.github/scripts/exec-deploy.sh
@@ -1,3 +1,5 @@
+set -euo pipefail
+
 # connect to ssh
 mkdir -p ~/.ssh/
 echo "${SSH_PRIVATE_KEY}" >>~/.ssh/ssh-key.pem

--- a/.github/scripts/exec-publish.sh
+++ b/.github/scripts/exec-publish.sh
@@ -1,3 +1,5 @@
+set -euo pipefail
+
 # image name
 IMAGE_NAME="${DOCKER_USERNAME}/${DOCKER_IMAGE_NAME}"
 


### PR DESCRIPTION
Add `set -euo pipefail` to all pipeline scripts so any command failure immediately exits the script with a non-zero code.